### PR TITLE
Editorial redesign across all pages with mobile pass

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="{{ site.baseurl }}/css/design-system.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/css/cards.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/css/blog-post.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/pages.css">
 
     <!-- Custom Styles -->
     <style>
@@ -60,7 +61,6 @@
             display: block;
         }
 
-        /* Gradient Text */
         .gradient-text {
             background: linear-gradient(45deg, #00bfa5, #40E0D0);
             -webkit-background-clip: text;
@@ -69,7 +69,6 @@
             display: inline-block;
         }
 
-        /* Navigation styles */
         .nav-fixed {
             position: fixed;
             top: 0;
@@ -85,126 +84,31 @@
     </style>
     <script type="text/javascript" id="MathJax-script" async
         src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
-        </script>
+    </script>
 </head>
 
 <body class="bg-[#1e1e1e]">
-    <!-- Header will be injected here -->
     {% include header.html %}
 
-    <!DOCTYPE html>
-    <html lang="en">
+    <!-- Content -->
+    {{ content }}
 
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>{% if page.title %}{{ page.title }} - {% endif %}Salvium Protocol</title>
+    {% include footer.html %}
 
-        <!-- Favicons -->
-        <link rel="icon" type="image/svg+xml" href="{{ site.baseurl }}/favicon/favicon.svg">
+    <!-- Scripts -->
+    <script>
+        window.jekyllPaths = {
+            root: '{{ site.baseurl }}',
+            images: '{{ site.baseurl }}/images',
+            css: '{{ site.baseurl }}/css',
+            js: '{{ site.baseurl }}/js'
+        };
+    </script>
+    <script src="{{ site.baseurl }}/js/navigation.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
+    <script>
+        AOS.init();
+    </script>
+</body>
 
-        <!-- Fonts and Styles -->
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link rel="stylesheet" href="{{ site.baseurl }}/css/typography.css">
-        <link href="https://unpkg.com/tailwindcss@^2.2.19/dist/tailwind.min.css" rel="stylesheet">
-        <link href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.css" rel="stylesheet">
-        <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
-        <link rel="stylesheet" href="{{ site.baseurl }}/css/design-system.css">
-        <link rel="stylesheet" href="{{ site.baseurl }}/css/cards.css">
-        <link rel="stylesheet" href="{{ site.baseurl }}/css/blog-post.css">
-
-        <!-- Custom Styles -->
-        <style>
-            :root {
-                --color-primary: #00bfa5;
-                --color-primary-dark: #009688;
-                --color-bg-dark: #1e1e1e;
-                --color-bg-darker: rgba(30, 30, 30, 0.95);
-                --color-text: #e0e0e0;
-                --font-primary: 'Josefin Sans', sans-serif;
-                --radius-sm: 2px;
-                --radius-md: 4px;
-                --radius-lg: 4px;
-            }
-
-            * {
-                -webkit-tap-highlight-color: transparent;
-            }
-
-            html,
-            body {
-                overflow-x: hidden;
-                width: 100%;
-                -webkit-font-smoothing: antialiased;
-                -moz-osx-font-smoothing: grayscale;
-            }
-
-            body {
-                font-family: var(--font-primary);
-                background-color: var(--color-bg-dark);
-                color: var(--color-text);
-            }
-
-            .mobile-menu {
-                display: none;
-            }
-
-            .mobile-menu.active {
-                display: block;
-            }
-
-            /* Gradient Text */
-            .gradient-text {
-                background: linear-gradient(45deg, #00bfa5, #40E0D0);
-                -webkit-background-clip: text;
-                -webkit-text-fill-color: transparent;
-                background-clip: text;
-                display: inline-block;
-            }
-
-            /* Navigation styles */
-            .nav-fixed {
-                position: fixed;
-                top: 0;
-                left: 0;
-                right: 0;
-                z-index: 50;
-                background: linear-gradient(to bottom, rgba(30, 30, 30, 0.19), rgba(30, 30, 30, 0.61));
-                backdrop-filter: blur(8px);
-                -webkit-backdrop-filter: blur(8px);
-                border-bottom: 1px solid rgba(0, 191, 165, 0.1);
-                transition: all 0.3s ease;
-            }
-        </style>
-        <script type="text/javascript" id="MathJax-script" async
-            src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
-            </script>
-    </head>
-
-    <body class="bg-[#1e1e1e]">
-        <!-- Header will be injected here -->
-        {% include header.html %}
-
-        <!-- Content -->
-        {{ content }}
-
-        {% include footer.html %}
-
-        <!-- Scripts -->
-        <script>
-            window.jekyllPaths = {
-                root: '{{ site.baseurl }}',
-                images: '{{ site.baseurl }}/images',
-                css: '{{ site.baseurl }}/css',
-                js: '{{ site.baseurl }}/js'
-            };
-        </script>
-        <script src="{{ site.baseurl }}/js/navigation.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.4/aos.js"></script>
-        <script>
-            AOS.init();
-        </script>
-    </body>
-
-    </html>
+</html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -44,10 +44,18 @@
             --radius-lg: 4px;
         }
 
+        html,
+        body {
+            overflow-x: hidden;
+            max-width: 100%;
+        }
+
         body {
             font-family: var(--font-primary);
             background-color: var(--color-bg-dark);
             color: var(--color-text);
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
         }
 
         .mobile-menu {

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,36 +3,35 @@ layout: blog
 ---
 <link rel="stylesheet" href="{{ site.baseurl }}/blog/assets/css/blog.css">
 
-<main class="relative z-10 pt-16">
+<main class="relative z-10 pt-16 post-page">
     <article class="container mx-auto px-2 sm:px-4">
         <div class="max-w-4xl mx-auto">
             <!-- Header Image -->
-            <div class="relative mb-6 md:mb-8 -mx-2 sm:mx-0">
+            <div class="post-page__media -mx-2 sm:mx-0">
                 {% if page.image %}
-                <img src="{{ page.image | relative_url }}" alt="{{ page.title }}"
-                    class="w-full h-[400px] md:h-[450px] lg:h-[600px] object-cover object-center">
+                <img src="{{ page.image | relative_url }}" alt="{{ page.title }}">
                 {% else %}
-                <img src="{{ '/images/newimages/Page Headers/Blog Header.jpg' | relative_url }}" alt="Blog Header"
-                    class="w-full h-[400px] md:h-[450px] lg:h-[600px] object-cover object-center">
+                <img src="{{ '/images/newimages/Page Headers/Blog Header.jpg' | relative_url }}" alt="">
                 {% endif %}
             </div>
 
-            <div class="py-2 md:py-4">
-                <h1 class="text-3xl md:text-4xl lg:text-5xl font-bold text-white mb-4 font-heading leading-tight">{{
-                    page.title }}</h1>
-                <div class="flex flex-wrap items-center text-gray-300 text-lg mb-4 md:mb-6">
-                    <time datetime="{{ page.date | date_to_xmlschema }}" class="font-medium">{{ page.date | date: "%B
-                        %d, %Y" }}</time>
-                    {% if page.categories %}
-                    <span class="mx-2 text-[#40E0D0]">•</span>
-                    <span
-                        style="background: rgba(0, 191, 165, 0.1); color: #00bfa5; padding: 0.375rem 1rem; border-radius: 2px; font-size: 1rem; display: inline-block; font-family: 'Inter', Arial, sans-serif; text-transform: uppercase;">{{
-                        page.categories | first }}</span>
+            <header class="post-page__header">
+                {% if page.categories.size > 0 %}
+                <span class="section-eyebrow">{{ page.categories | first }}</span>
+                {% else %}
+                <span class="section-eyebrow">Update</span>
+                {% endif %}
+                <h1 class="post-page__title">{{ page.title }}</h1>
+                <div class="post-page__meta">
+                    <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%b %d, %Y" }}</time>
+                    {% if page.author %}
+                    <span class="post-page__meta-sep" aria-hidden="true"></span>
+                    <span class="post-page__author">{{ page.author }}</span>
                     {% endif %}
                 </div>
-            </div>
+            </header>
 
-            <div class="prose prose-lg mx-auto bg-[#2a2a2a] rounded-none shadow-lg mb-12 p-4 sm:p-6 md:p-8">
+            <div class="prose prose-lg mx-auto post-page__body">
                 {{ content }}
             </div>
         </div>

--- a/about.html
+++ b/about.html
@@ -7,27 +7,24 @@ redirect_from:
 ---
 
 <main class="relative z-10">
-    <!-- Hero Section -->
-    <section class="relative">
-        <!-- Hero Image -->
-        <div class="absolute inset-0">
+    <!-- Hero -->
+    <section class="page-hero">
+        <div class="page-hero__bg">
             <picture>
                 <source srcset="{{ site.baseurl }}/images/newimages/About.webp" type="image/webp">
-                <img src="{{ site.baseurl }}/images/newimages/About.png" alt="About Salvium"
-                    class="w-full h-full object-cover opacity-30">
+                <img src="{{ site.baseurl }}/images/newimages/About.png" alt="">
             </picture>
-            <div class="absolute inset-0 bg-gradient-to-r from-black to-transparent opacity-75"></div>
+            <div class="page-hero__overlay"></div>
         </div>
-        <div class="relative z-10 py-24 lg:py-32">
-            <div class="container mx-auto px-4">
-                <div class="max-w-4xl mx-auto text-center">
-                    <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 text-center">
-                        About <span class="gradient-text">Salvium</span>
-                    </h1>
-                    <p class="text-xl text-gray-300 mb-8 text-center mx-auto max-w-2xl">
-                        Revolutionizing DeFi through innovation, security, and accessibility.
-                    </p>
-                </div>
+        <div class="container relative z-10">
+            <div class="page-hero__inner" data-aos="fade-up" data-aos-duration="900">
+                <span class="section-eyebrow">About</span>
+                <h1 class="page-hero__title">
+                    About <span class="gradient-text">Salvium</span>
+                </h1>
+                <p class="page-hero__lede">
+                    Revolutionizing DeFi through innovation, security, and accessibility.
+                </p>
             </div>
         </div>
     </section>
@@ -142,25 +139,21 @@ redirect_from:
         </div>
     </section>
 
-    <!-- CTA Section -->
-    <section class="py-16 relative overflow-hidden bg-[#0B272C] mt-8">
-        <!-- Background Decoration -->
-        <div class="absolute inset-0">
-            <img src="{{ site.baseurl }}/images/pools-1024.webp" alt=""
-                class="absolute w-full h-full object-cover opacity-20">
-            <div class="absolute inset-0 bg-gradient-to-b from-[#0B272C]/95 via-[#0B272C]/80 to-[#0B272C]/95"></div>
+    <!-- CTA -->
+    <section class="page-cta">
+        <div class="page-cta__bg">
+            <img src="{{ site.baseurl }}/images/pools-1024.webp" alt="">
+            <div class="page-cta__overlay"></div>
         </div>
-
-        <div class="container mx-auto px-4 text-center relative z-10">
-            <h2 class="text-4xl md:text-5xl font-bold mb-8" data-aos="fade-up">
+        <div class="container relative z-10 text-center">
+            <span class="section-eyebrow" data-aos="fade-up">Get Started</span>
+            <h2 class="page-cta__title" data-aos="fade-up" data-aos-delay="100">
                 Ready to Take the <span class="gradient-text">Pill</span>?
             </h2>
-            <p class="text-xl text-white/80 mb-10 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">
+            <p class="page-cta__lede" data-aos="fade-up" data-aos-delay="200">
                 Start your journey with Salvium today and be part of the next generation of Private DeFi.
             </p>
-            <a href="{% link download.html %}"
-                class="btn-primary px-12 py-4 text-lg font-semibold hover:opacity-90 transition-opacity inline-block"
-                data-aos="fade-up" data-aos-delay="200">
+            <a href="{% link download.html %}" class="btn-primary page-cta__btn" data-aos="fade-up" data-aos-delay="300">
                 Get Started Now
             </a>
         </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -21,25 +21,22 @@ title: Blog
 <link rel="stylesheet" href="{{ site.baseurl }}/blog/assets/css/blog.css">
 
 <main class="relative z-10 pt-16">
-    <!-- Hero Section -->
-    <section class="relative">
-        <!-- Hero Image -->
-        <div class="absolute inset-0">
-            <img src="{{ site.baseurl }}/images/newimages/Page Headers/Blog Header.webp" alt="Blog Header"
-                class="w-full h-full object-cover opacity-30" width="1920" height="1080" loading="eager"
-                fetchpriority="high">
-            <div class="absolute inset-0 bg-gradient-to-r from-black to-transparent opacity-75"></div>
+    <!-- Hero -->
+    <section class="page-hero">
+        <div class="page-hero__bg">
+            <img src="{{ site.baseurl }}/images/newimages/Page Headers/Blog Header.webp" alt=""
+                width="1920" height="1080" loading="eager" fetchpriority="high">
+            <div class="page-hero__overlay"></div>
         </div>
-        <div class="relative z-10 py-28 lg:py-36">
-            <div class="container mx-auto px-4">
-                <div class="max-w-4xl mx-auto text-center">
-                    <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 text-center">
-                        Salvium <span class="gradient-text">Blog</span>
-                    </h1>
-                    <p class="text-xl text-gray-300 mb-8 text-center mx-auto max-w-2xl">
-                        Stay updated with the latest news, developments, and insights from the Salvium team.
-                    </p>
-                </div>
+        <div class="container relative z-10">
+            <div class="page-hero__inner" data-aos="fade-up" data-aos-duration="900">
+                <span class="section-eyebrow">Writing</span>
+                <h1 class="page-hero__title">
+                    Salvium <span class="gradient-text">Blog</span>
+                </h1>
+                <p class="page-hero__lede">
+                    Stay updated with the latest news, developments, and insights from the Salvium team.
+                </p>
             </div>
         </div>
     </section>
@@ -124,25 +121,21 @@ title: Blog
         {% endif %}
     </section>
 
-    <!-- CTA Section -->
-    <section class="py-16 relative overflow-hidden bg-[#0B272C] mt-8">
-        <!-- Background Decoration -->
-        <div class="absolute inset-0">
-            <img src="{{ site.baseurl }}/images/pools-1024.webp" alt=""
-                class="absolute w-full h-full object-cover opacity-20">
-            <div class="absolute inset-0 bg-gradient-to-b from-[#0B272C]/95 via-[#0B272C]/80 to-[#0B272C]/95"></div>
+    <!-- CTA -->
+    <section class="page-cta">
+        <div class="page-cta__bg">
+            <img src="{{ site.baseurl }}/images/pools-1024.webp" alt="">
+            <div class="page-cta__overlay"></div>
         </div>
-
-        <div class="container mx-auto px-4 text-center relative z-10">
-            <h2 class="text-4xl md:text-5xl font-bold mb-8" data-aos="fade-up">
+        <div class="container relative z-10 text-center">
+            <span class="section-eyebrow" data-aos="fade-up">Get Started</span>
+            <h2 class="page-cta__title" data-aos="fade-up" data-aos-delay="100">
                 Ready to Take the <span class="gradient-text">Pill</span>?
             </h2>
-            <p class="text-xl text-white/80 mb-10 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">
+            <p class="page-cta__lede" data-aos="fade-up" data-aos-delay="200">
                 Start your journey with Salvium today and be part of the next generation of Private DeFi.
             </p>
-            <a href="{% link download.html %}"
-                class="btn-primary px-12 py-4 text-lg font-semibold hover:opacity-90 transition-opacity inline-block"
-                data-aos="fade-up" data-aos-delay="200">
+            <a href="{% link download.html %}" class="btn-primary page-cta__btn" data-aos="fade-up" data-aos-delay="300">
                 Get Started Now
             </a>
         </div>

--- a/community.html
+++ b/community.html
@@ -8,23 +8,21 @@ redirect_from:
 
 <div class="main-wrapper">
     <main class="relative z-10">
-        <!-- Hero Section -->
-        <section class="relative bg-[#1e1e1e] overflow-hidden">
-            <div class="absolute inset-0">
-                <img src="{{ site.baseurl }}/images/newimages/Page Headers/Commnunity Header-1024.webp"
-                    alt="Community Header" class="w-full h-full object-cover opacity-30">
-                <div class="absolute inset-0 bg-gradient-to-b from-[#1e1e1e]/80 to-[#1e1e1e]"></div>
+        <!-- Hero -->
+        <section class="page-hero">
+            <div class="page-hero__bg">
+                <img src="{{ site.baseurl }}/images/newimages/Page Headers/Commnunity Header-1024.webp" alt="">
+                <div class="page-hero__overlay"></div>
             </div>
-            <div class="relative z-10 py-24 lg:py-32">
-                <div class="container mx-auto px-4">
-                    <div class="max-w-4xl mx-auto text-center">
-                        <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
-                            Join Our <span class="gradient-text">Community</span>
-                        </h1>
-                        <p class="text-xl text-gray-300 mb-8">
-                            Connect with fellow Salvium enthusiasts and stay updated on the latest developments
-                        </p>
-                    </div>
+            <div class="container relative z-10">
+                <div class="page-hero__inner" data-aos="fade-up" data-aos-duration="900">
+                    <span class="section-eyebrow">Get Involved</span>
+                    <h1 class="page-hero__title">
+                        Join Our <span class="gradient-text">Community</span>
+                    </h1>
+                    <p class="page-hero__lede">
+                        Connect with fellow Salvium enthusiasts and stay updated on the latest developments.
+                    </p>
                 </div>
             </div>
         </section>
@@ -111,25 +109,21 @@ redirect_from:
         </section>
     </main>
 
-    <!-- CTA Section -->
-    <section class="py-16 relative overflow-hidden bg-[#0B272C] mt-4">
-        <!-- Background Decoration -->
-        <div class="absolute inset-0">
-            <img src="{{ site.baseurl }}/images/pools-1024.webp" alt=""
-                class="absolute w-full h-full object-cover opacity-20">
-            <div class="absolute inset-0 bg-gradient-to-b from-[#0B272C]/95 via-[#0B272C]/80 to-[#0B272C]/95"></div>
+    <!-- CTA -->
+    <section class="page-cta">
+        <div class="page-cta__bg">
+            <img src="{{ site.baseurl }}/images/pools-1024.webp" alt="">
+            <div class="page-cta__overlay"></div>
         </div>
-
-        <div class="container mx-auto px-4 text-center relative z-10">
-            <h2 class="text-4xl md:text-5xl font-bold mb-8" data-aos="fade-up">
+        <div class="container relative z-10 text-center">
+            <span class="section-eyebrow" data-aos="fade-up">Get Started</span>
+            <h2 class="page-cta__title" data-aos="fade-up" data-aos-delay="100">
                 Ready to Take the <span class="gradient-text">Pill</span>?
             </h2>
-            <p class="text-xl text-white/80 mb-10 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">
+            <p class="page-cta__lede" data-aos="fade-up" data-aos-delay="200">
                 Start your journey with Salvium today and be part of the next generation of Private DeFi.
             </p>
-            <a href="{% link about.html %}"
-                class="btn-primary px-12 py-4 text-lg font-semibold hover:opacity-90 transition-opacity inline-block"
-                data-aos="fade-up" data-aos-delay="200">
+            <a href="{% link about.html %}" class="btn-primary page-cta__btn" data-aos="fade-up" data-aos-delay="300">
                 Get Started Now
             </a>
         </div>

--- a/css/pages.css
+++ b/css/pages.css
@@ -302,3 +302,761 @@ section[id] {
     display: block;
     margin-bottom: 0.25rem;
 }
+
+/* ==========================================================================
+   Home Page (index.html)
+   Scoped under .home- prefixes so styles do not leak into other pages.
+   ========================================================================== */
+
+/* Editorial eyebrow used above section headings ---------------------------- */
+.section-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    row-gap: 0.25rem;
+    max-width: 100%;
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.72rem;
+    font-weight: 500;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: #40E0D0;
+}
+
+.section-eyebrow::before {
+    content: "";
+    width: 1.5rem;
+    height: 1px;
+    background: #40E0D0;
+    margin-right: 0.7rem;
+    opacity: 0.65;
+}
+
+/* Hairline divider between top-level page sections ------------------------ */
+/* Distinct from the original .section-divider (line ~88) which is used for  */
+/* inline content dividers on about.html / faq.html with vertical margin.    */
+.page-divider {
+    height: 1px;
+    border: 0;
+    background: linear-gradient(90deg, transparent, rgba(0, 191, 165, 0.18), transparent);
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+/* Generic home section layout --------------------------------------------- */
+.page-section {
+    padding: clamp(4rem, 8vw, 6.5rem) 0;
+    position: relative;
+}
+
+.page-section__head {
+    max-width: 720px;
+    margin: 0 auto 3rem;
+    text-align: center;
+}
+
+.page-section__head--row {
+    max-width: 1200px;
+    text-align: left;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.page-section__title {
+    font-family: var(--font-heading, 'Josefin Sans', sans-serif);
+    font-size: clamp(2rem, 4vw, 2.75rem);
+    font-weight: 700;
+    color: #fff;
+    margin: 0.6rem 0 1rem;
+    letter-spacing: -0.015em;
+    line-height: 1.15;
+}
+
+.page-section__lede {
+    color: rgba(255, 255, 255, 0.72);
+    font-size: 1.0625rem;
+    line-height: 1.65;
+    max-width: 56ch;
+    margin: 0;
+}
+
+.page-section__head:not(.page-section__head--row) .page-section__lede {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+@media (max-width: 720px) {
+    .page-section__head--row {
+        align-items: flex-start;
+    }
+}
+
+/* Hero -------------------------------------------------------------------- */
+.page-hero {
+    padding: clamp(7rem, 14vw, 11rem) 0 clamp(4rem, 9vw, 7rem);
+    position: relative;
+    overflow: hidden;
+}
+
+.page-hero__bg {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+}
+
+.page-hero__bg img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+    opacity: 0.38;
+}
+
+.page-hero__overlay {
+    position: absolute;
+    inset: 0;
+    background:
+        radial-gradient(ellipse at 25% 30%, rgba(0, 191, 165, 0.10), transparent 55%),
+        linear-gradient(to bottom, rgba(30, 30, 30, 0.78), rgba(30, 30, 30, 0.62) 45%, rgba(30, 30, 30, 1));
+}
+
+.page-hero__inner {
+    max-width: 760px;
+}
+
+.page-hero__title {
+    font-family: var(--font-heading, 'Josefin Sans', sans-serif);
+    font-size: clamp(2.5rem, 6vw, 4.5rem);
+    font-weight: 700;
+    color: #fff;
+    line-height: 1.05;
+    letter-spacing: -0.025em;
+    margin: 1.1rem 0 1.5rem;
+}
+
+.page-hero__title .gradient-text {
+    display: inline-block;
+}
+
+.page-hero__lede {
+    font-size: clamp(1.0625rem, 1.6vw, 1.25rem);
+    color: rgba(255, 255, 255, 0.86);
+    line-height: 1.55;
+    max-width: 36rem;
+    margin: 0 0 2rem;
+}
+
+.page-hero__cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.875rem;
+    margin-bottom: 2.75rem;
+}
+
+.page-hero__btn {
+    padding: 0.95rem 1.75rem;
+    font-weight: 600;
+    font-size: 0.95rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    text-decoration: none;
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, border-color 0.25s ease;
+}
+
+.page-hero__btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 14px 32px -14px rgba(0, 191, 165, 0.55);
+}
+
+.page-hero__btn--ghost {
+    border: 1px solid rgba(64, 224, 208, 0.55);
+    background: rgba(64, 224, 208, 0.04);
+}
+
+.page-hero__btn--ghost:hover {
+    background: rgba(64, 224, 208, 0.10);
+    border-color: rgba(64, 224, 208, 0.9);
+}
+
+/* Trust strip in hero ----------------------------------------------------- */
+.trust-strip {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    padding: 0.85rem 1.25rem;
+    border-top: 1px solid rgba(0, 191, 165, 0.20);
+    border-bottom: 1px solid rgba(0, 191, 165, 0.20);
+    background: linear-gradient(90deg, rgba(0, 191, 165, 0.05), rgba(0, 191, 165, 0));
+}
+
+.trust-strip__item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0 1.1rem;
+}
+
+.trust-strip__item:first-child {
+    padding-left: 0;
+}
+
+.trust-strip__item:last-child {
+    padding-right: 0;
+}
+
+.trust-strip__icon {
+    width: 1.1rem;
+    height: 1.1rem;
+    flex-shrink: 0;
+}
+
+.trust-strip__icon-fa {
+    color: #40E0D0;
+    font-size: 1rem;
+    width: 1.1rem;
+    text-align: center;
+}
+
+.trust-strip__label {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.78rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.92);
+}
+
+.trust-strip__sep {
+    width: 1px;
+    height: 1.1rem;
+    background: rgba(0, 191, 165, 0.30);
+}
+
+@media (max-width: 540px) {
+    .trust-strip { padding: 0.75rem 0.85rem; }
+    .trust-strip__item { padding: 0 0.7rem; }
+    .trust-strip__label { font-size: 0.72rem; letter-spacing: 0.14em; }
+}
+
+/* MiCAR milestone banner -------------------------------------------------- */
+.milestone-banner {
+    border-top: 1px solid rgba(0, 191, 165, 0.22);
+    border-bottom: 1px solid rgba(0, 191, 165, 0.22);
+    background:
+        repeating-linear-gradient(135deg, rgba(0, 191, 165, 0.025) 0 1px, transparent 1px 14px),
+        linear-gradient(90deg, rgba(0, 191, 165, 0.10), rgba(11, 39, 44, 0.55));
+    position: relative;
+}
+
+.milestone-banner__inner {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 1.5rem;
+    padding-top: 1.4rem;
+    padding-bottom: 1.4rem;
+}
+
+.milestone-banner__icon {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 4px;
+    background: rgba(0, 191, 165, 0.12);
+    border: 1px solid rgba(0, 191, 165, 0.35);
+    color: #40E0D0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.05rem;
+    flex-shrink: 0;
+}
+
+.milestone-banner__copy {
+    min-width: 0;
+}
+
+.milestone-banner__eyebrow {
+    margin-bottom: 0.3rem;
+}
+
+.milestone-banner__headline {
+    color: #fff;
+    font-size: clamp(0.95rem, 1.6vw, 1.1rem);
+    line-height: 1.45;
+    margin: 0;
+    overflow-wrap: anywhere;
+    word-break: normal;
+}
+
+.milestone-banner__headline strong {
+    color: #fff;
+    font-weight: 600;
+}
+
+.milestone-banner__link {
+    font-family: var(--font-heading, 'Josefin Sans', sans-serif);
+    color: #40E0D0;
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.82rem;
+    letter-spacing: 0.16em;
+    white-space: nowrap;
+    text-decoration: none;
+    transition: color 0.2s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.milestone-banner__link:hover {
+    color: #fff;
+}
+
+.milestone-banner__link span {
+    transition: transform 0.2s ease;
+}
+
+.milestone-banner__link:hover span {
+    transform: translateX(3px);
+}
+
+@media (max-width: 820px) {
+    .milestone-banner__inner {
+        grid-template-columns: auto 1fr;
+        gap: 0.9rem 1.1rem;
+        padding-top: 1.2rem;
+        padding-bottom: 1.2rem;
+    }
+    .milestone-banner__link {
+        grid-column: 1 / -1;
+        justify-self: start;
+    }
+}
+
+@media (max-width: 540px) {
+    .milestone-banner {
+        overflow: hidden;
+    }
+    .milestone-banner__inner {
+        grid-template-columns: 1fr;
+        gap: 0.7rem;
+        padding-top: 1.05rem;
+        padding-bottom: 1.05rem;
+    }
+    .milestone-banner__icon {
+        width: 2.1rem;
+        height: 2.1rem;
+        font-size: 0.95rem;
+    }
+    .milestone-banner__copy {
+        min-width: 0;
+        max-width: 100%;
+    }
+    /* Drop the eyebrow's leading dash on the banner — frees up width */
+    .milestone-banner .section-eyebrow::before {
+        display: none;
+    }
+    .milestone-banner__eyebrow {
+        margin-bottom: 0.25rem;
+        font-size: 0.65rem;
+        letter-spacing: 0.12em;
+    }
+    .milestone-banner__headline {
+        font-size: 0.9rem;
+        line-height: 1.5;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+    }
+    .milestone-banner__link {
+        white-space: normal;
+        font-size: 0.78rem;
+        letter-spacing: 0.14em;
+        max-width: 100%;
+    }
+}
+
+/* Card refinements (home-scoped) ----------------------------------------- */
+.page-card {
+    border-color: rgba(0, 191, 165, 0.06);
+    position: relative;
+}
+
+.page-card .card-content {
+    padding: 1.5rem;
+    padding-top: 1.25rem;
+}
+
+.page-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    border-top: 1px solid transparent;
+    transition: border-color 0.3s ease;
+    z-index: 1;
+}
+
+.page-card:hover::before {
+    border-top-color: rgba(64, 224, 208, 0.55);
+}
+
+.page-card__media {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 10;
+    overflow: hidden;
+}
+
+.page-card__media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.6s cubic-bezier(0.2, 0.6, 0.2, 1);
+    display: block;
+}
+
+.page-card:hover .page-card__media img {
+    transform: scale(1.04);
+}
+
+/* Latest from the Blog ---------------------------------------------------- */
+.home-latest__viewall {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.78rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: #40E0D0;
+    text-decoration: none;
+    border: 1px solid rgba(64, 224, 208, 0.35);
+    padding: 0.7rem 1.1rem;
+    transition: background 0.25s ease, border-color 0.25s ease, color 0.25s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    flex-shrink: 0;
+}
+
+.home-latest__viewall:hover {
+    background: rgba(64, 224, 208, 0.10);
+    border-color: rgba(64, 224, 208, 0.7);
+    color: #fff;
+}
+
+.home-post-card__media-link {
+    display: block;
+    overflow: hidden;
+}
+
+.home-post-card__meta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.65rem;
+    flex-wrap: wrap;
+}
+
+.home-post-card__date {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.55);
+    font-feature-settings: "tnum" 1;
+}
+
+.home-post-card .card-title {
+    font-size: 1.2rem;
+    line-height: 1.35;
+    margin-bottom: 0.6rem;
+}
+
+.home-post-card__title-link {
+    color: inherit;
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.home-post-card__title-link:hover {
+    color: #40E0D0;
+}
+
+/* CTA --------------------------------------------------------------------- */
+.page-cta {
+    padding: clamp(4.5rem, 9vw, 7rem) 0;
+    background: #0B272C;
+    position: relative;
+    overflow: hidden;
+    margin-top: 2rem;
+}
+
+.page-cta__bg {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+}
+
+.page-cta__bg img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0.18;
+}
+
+.page-cta__overlay {
+    position: absolute;
+    inset: 0;
+    background:
+        radial-gradient(ellipse at center, rgba(0, 191, 165, 0.12), transparent 65%),
+        linear-gradient(to bottom, rgba(11, 39, 44, 0.95), rgba(11, 39, 44, 0.78), rgba(11, 39, 44, 0.95));
+}
+
+.page-cta__title {
+    font-family: var(--font-heading, 'Josefin Sans', sans-serif);
+    font-size: clamp(2.25rem, 5vw, 3.25rem);
+    font-weight: 700;
+    color: #fff;
+    line-height: 1.1;
+    letter-spacing: -0.015em;
+    margin: 1rem auto 1.25rem;
+    max-width: 22ch;
+}
+
+.page-cta__lede {
+    color: rgba(255, 255, 255, 0.82);
+    font-size: 1.125rem;
+    line-height: 1.6;
+    max-width: 38rem;
+    margin: 0 auto 2.5rem;
+}
+
+.page-cta__btn {
+    padding: 1.05rem 2.5rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    display: inline-flex;
+    align-items: center;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.page-cta__btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 40px -14px rgba(0, 191, 165, 0.6);
+}
+
+/* ==========================================================================
+   Blog post page (_layouts/post.html)
+   ========================================================================== */
+
+.post-page__media {
+    position: relative;
+    margin-bottom: 2rem;
+    overflow: hidden;
+}
+
+.post-page__media img {
+    width: 100%;
+    height: clamp(280px, 45vw, 560px);
+    object-fit: cover;
+    object-position: center;
+    display: block;
+}
+
+.post-page__media::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: linear-gradient(to bottom, transparent 60%, rgba(30, 30, 30, 0.55));
+}
+
+.post-page__header {
+    padding: 0 0 1.75rem;
+    border-bottom: 1px solid rgba(0, 191, 165, 0.12);
+    margin-bottom: 2.5rem;
+}
+
+.post-page__title {
+    font-family: var(--font-heading, 'Josefin Sans', sans-serif);
+    font-size: clamp(1.85rem, 4.2vw, 3rem);
+    font-weight: 700;
+    color: #fff;
+    line-height: 1.12;
+    letter-spacing: -0.018em;
+    margin: 0.85rem 0 1.1rem;
+}
+
+.post-page__meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.85rem;
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 0.78rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.62);
+    font-feature-settings: "tnum" 1;
+}
+
+.post-page__meta time {
+    color: rgba(255, 255, 255, 0.78);
+}
+
+.post-page__meta-sep {
+    width: 1px;
+    height: 0.85rem;
+    background: rgba(0, 191, 165, 0.35);
+}
+
+.post-page__author {
+    color: rgba(255, 255, 255, 0.62);
+}
+
+.post-page__body {
+    background: #2a2a2a;
+    padding: clamp(1.25rem, 3vw, 2.5rem);
+    margin-bottom: 3rem;
+    box-shadow: 0 1px 0 rgba(0, 191, 165, 0.08) inset;
+}
+
+/* ==========================================================================
+   Mobile optimisations for the redesign tokens
+   ========================================================================== */
+
+/* Tablet & phone ----------------------------------------------------------- */
+@media (max-width: 768px) {
+    .page-hero {
+        padding: 6rem 0 3.25rem;
+    }
+    .page-hero__inner {
+        max-width: 100%;
+    }
+    .page-hero__title {
+        font-size: clamp(2.1rem, 8vw, 3rem);
+        margin: 0.85rem 0 1.1rem;
+    }
+    .page-hero__lede {
+        font-size: 1rem;
+        margin-bottom: 1.5rem;
+    }
+    .page-hero__cta {
+        margin-bottom: 2rem;
+    }
+
+    .page-section {
+        padding: 3.5rem 0;
+    }
+    .page-section__head {
+        margin-bottom: 2.25rem;
+    }
+    .page-section__title {
+        font-size: clamp(1.65rem, 6.5vw, 2.25rem);
+    }
+    .page-section__lede {
+        font-size: 1rem;
+    }
+
+    .page-cta {
+        padding: 3.75rem 0;
+        margin-top: 1.5rem;
+    }
+    .page-cta__title {
+        font-size: clamp(1.85rem, 6.5vw, 2.4rem);
+        margin-bottom: 1rem;
+    }
+    .page-cta__lede {
+        font-size: 1rem;
+        margin-bottom: 1.85rem;
+    }
+
+    .post-page__media {
+        margin-bottom: 1.5rem;
+    }
+    .post-page__media img {
+        height: clamp(220px, 60vw, 360px);
+    }
+    .post-page__header {
+        padding-bottom: 1.25rem;
+        margin-bottom: 1.85rem;
+    }
+    .post-page__title {
+        font-size: clamp(1.55rem, 6vw, 2.2rem);
+        margin: 0.75rem 0 0.9rem;
+    }
+    .post-page__meta {
+        font-size: 0.7rem;
+        gap: 0.6rem;
+    }
+
+    .milestone-banner__headline {
+        font-size: 0.95rem;
+        line-height: 1.5;
+    }
+}
+
+/* Phone -------------------------------------------------------------------- */
+@media (max-width: 540px) {
+    /* Trust strip: stack vertically and drop the orphaned separators */
+    .trust-strip {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.55rem;
+        padding: 0.85rem 1rem;
+    }
+    .trust-strip__item {
+        padding: 0;
+    }
+    .trust-strip__sep {
+        display: none;
+    }
+
+    /* Hero CTA: full-width stacked buttons feel intentional vs marooned */
+    .page-hero__cta {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.65rem;
+    }
+    .page-hero__btn {
+        justify-content: center;
+        padding: 0.9rem 1.25rem;
+    }
+
+    /* CTA button: trim chunky padding */
+    .page-cta__btn {
+        padding: 0.95rem 1.75rem;
+        font-size: 0.9rem;
+    }
+
+    /* Latest-from-blog "All posts" pill */
+    .home-latest__viewall {
+        font-size: 0.72rem;
+        letter-spacing: 0.16em;
+        padding: 0.6rem 0.95rem;
+    }
+
+    /* Section eyebrow tightens up */
+    .section-eyebrow {
+        font-size: 0.68rem;
+        letter-spacing: 0.16em;
+    }
+    .section-eyebrow::before {
+        width: 1rem;
+        margin-right: 0.55rem;
+    }
+}
+
+/* Touch devices: disable card image hover-zoom (jitter on tap-then-scroll) */
+@media (hover: none) and (pointer: coarse) {
+    .page-card:hover .page-card__media img {
+        transform: none;
+    }
+}

--- a/donate.html
+++ b/donate.html
@@ -5,68 +5,71 @@ redirect_from:
   - /donate.html
 ---
 
-<h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 text-center">
-  Donate to <span class="gradient-text">Salvium</span>
-</h1>
-<p class="text-xl text-gray-300 mb-8 text-center">
-  Your support funds development, audits, and community initiatives. Thank you.
-</p>
-</div>
-</div>
-</div>
-</section>
-
-<!-- Donation Addresses -->
-<section class="container mx-auto px-4 py-12">
-  <div class="max-w-3xl mx-auto space-y-10">
-
-    <div>
-
-      <h2 class="text-2xl font-bold mb-2 mt-8">Standard Donation Address</h2>
-      <p class="text-white text-opacity-80 mb-3">Use this for regular SAL donations.</p>
-      <div class="rounded-lg border border-white border-opacity-10 bg-white bg-opacity-5 p-4">
-        <p class="font-mono text-sm md:text-base break-all">
-          SaLvdTpya4SEgMWDVQ9eDsgJJEwhB2pb5N4YZPMeVjg4BpwoigpKuTMS1TC92ziNyu5EvKaXLMy2LX8PXa1kNsRjBSYPTgyc3J5
+<main class="relative z-10">
+  <!-- Hero -->
+  <section class="page-hero">
+    <div class="page-hero__bg">
+      <div class="page-hero__overlay"></div>
+    </div>
+    <div class="container relative z-10">
+      <div class="page-hero__inner" data-aos="fade-up" data-aos-duration="900">
+        <span class="section-eyebrow">Support the Project</span>
+        <h1 class="page-hero__title">
+          Donate to <span class="gradient-text">Salvium</span>
+        </h1>
+        <p class="page-hero__lede">
+          Your support funds development, audits, and community initiatives. Thank you.
         </p>
       </div>
     </div>
+  </section>
 
-    <div>
-      <h2 class="text-2xl font-bold mb-2">Carrot Donation Address</h2>
-      <p class="text-white text-opacity-80 mb-3">Use this Carrot address if your wallet supports it.</p>
-      <div class="rounded-lg border border-white border-opacity-10 bg-white bg-opacity-5 p-4">
-        <p class="font-mono text-sm md:text-base break-all">
-          SC11SxSj5yuT71WCWB1VsthazjnakytLLZrdpD3k7RKGVQEWH57w6zNbvhvP14dheJNiGwvwy3Fp915khxe1KMGuAea3anrm8a
-        </p>
+  <!-- Donation Addresses -->
+  <section class="container mx-auto px-4 py-12">
+    <div class="max-w-3xl mx-auto space-y-10">
+
+      <div>
+        <h2 class="text-2xl font-bold mb-2 mt-8">Standard Donation Address</h2>
+        <p class="text-white text-opacity-80 mb-3">Use this for regular SAL donations.</p>
+        <div class="rounded-lg border border-white border-opacity-10 bg-white bg-opacity-5 p-4">
+          <p class="font-mono text-sm md:text-base break-all">
+            SaLvdTpya4SEgMWDVQ9eDsgJJEwhB2pb5N4YZPMeVjg4BpwoigpKuTMS1TC92ziNyu5EvKaXLMy2LX8PXa1kNsRjBSYPTgyc3J5
+          </p>
+        </div>
+      </div>
+
+      <div>
+        <h2 class="text-2xl font-bold mb-2">Carrot Donation Address</h2>
+        <p class="text-white text-opacity-80 mb-3">Use this Carrot address if your wallet supports it.</p>
+        <div class="rounded-lg border border-white border-opacity-10 bg-white bg-opacity-5 p-4">
+          <p class="font-mono text-sm md:text-base break-all">
+            SC11SxSj5yuT71WCWB1VsthazjnakytLLZrdpD3k7RKGVQEWH57w6zNbvhvP14dheJNiGwvwy3Fp915khxe1KMGuAea3anrm8a
+          </p>
+        </div>
+      </div>
+
+      <div class="text-white text-opacity-70 text-sm">
+        <p>Always verify the address before sending. On-chain transactions are irreversible.</p>
       </div>
     </div>
-
-    <div class="text-white text-opacity-70 text-sm">
-      <p>Always verify the address before sending. On-chain transactions are irreversible.</p>
-    </div>
-  </div>
-</section>
+  </section>
 </main>
 
-
-<!-- CTA Section -->
-<section class="py-16 relative overflow-hidden bg-[#0B272C] mt-8">
-  <!-- Background Decoration -->
-  <div class="absolute inset-0">
-    <img src="{{ site.baseurl }}/images/pools-1024.webp" alt="" class="absolute w-full h-full object-cover opacity-20">
-    <div class="absolute inset-0 bg-gradient-to-b from-[#0B272C]/95 via-[#0B272C]/80 to-[#0B272C]/95"></div>
+<!-- CTA -->
+<section class="page-cta">
+  <div class="page-cta__bg">
+    <img src="{{ site.baseurl }}/images/pools-1024.webp" alt="">
+    <div class="page-cta__overlay"></div>
   </div>
-
-  <div class="container mx-auto px-4 text-center relative z-10">
-    <h2 class="text-4xl md:text-5xl font-bold mb-8" data-aos="fade-up">
+  <div class="container relative z-10 text-center">
+    <span class="section-eyebrow" data-aos="fade-up">Get Started</span>
+    <h2 class="page-cta__title" data-aos="fade-up" data-aos-delay="100">
       Ready to Take the <span class="gradient-text">Pill</span>?
     </h2>
-    <p class="text-xl text-white/80 mb-10 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">
+    <p class="page-cta__lede" data-aos="fade-up" data-aos-delay="200">
       Start your journey with Salvium today and be part of the next generation of Private DeFi.
     </p>
-    <a href="{% link download.html %}"
-      class="btn-primary px-12 py-4 text-lg font-semibold hover:opacity-90 transition-opacity inline-block"
-      data-aos="fade-up" data-aos-delay="200">
+    <a href="{% link download.html %}" class="btn-primary page-cta__btn" data-aos="fade-up" data-aos-delay="300">
       Get Started Now
     </a>
   </div>

--- a/download.html
+++ b/download.html
@@ -9,23 +9,21 @@ redirect_from:
 <!-- Main Content -->
 <div class="main-wrapper">
   <main class="relative z-10">
-    <!-- Hero Section -->
-    <section class="relative bg-[#1e1e1e] overflow-hidden">
-      <div class="absolute inset-0">
-        <img src="{{ site.baseurl }}/images/newimages/Page Headers/Download Header-1024.webp" alt="Download Header"
-          class="w-full h-full object-cover opacity-30">
-        <div class="absolute inset-0 bg-gradient-to-b from-[#1e1e1e]/80 to-[#1e1e1e]"></div>
+    <!-- Hero -->
+    <section class="page-hero">
+      <div class="page-hero__bg">
+        <img src="{{ site.baseurl }}/images/newimages/Page Headers/Download Header-1024.webp" alt="">
+        <div class="page-hero__overlay"></div>
       </div>
-      <div class="relative z-10 py-24 lg:py-32">
-        <div class="container mx-auto px-4">
-          <div class="max-w-4xl mx-auto text-center">
-            <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
-              Salvium <span class="gradient-text">Downloads</span>
-            </h1>
-            <p class="text-xl text-gray-300 mb-8">
-              Get started with Salvium wallets and tools
-            </p>
-          </div>
+      <div class="container relative z-10">
+        <div class="page-hero__inner" data-aos="fade-up" data-aos-duration="900">
+          <span class="section-eyebrow">Wallets &amp; Tools</span>
+          <h1 class="page-hero__title">
+            Salvium <span class="gradient-text">Downloads</span>
+          </h1>
+          <p class="page-hero__lede">
+            Get started with Salvium wallets and tools.
+          </p>
         </div>
       </div>
     </section>
@@ -218,24 +216,21 @@ redirect_from:
   </main>
 
 
-  <!-- CTA Section -->
-  <section class="py-16 relative overflow-hidden bg-[#0B272C] mt-4">
-    <div class="absolute inset-0">
-      <img src="{{ site.baseurl }}/images/pools-1024.webp" alt=""
-        class="absolute w-full h-full object-cover opacity-20">
-      <div class="absolute inset-0 bg-gradient-to-b from-[#0B272C]/95 via-[#0B272C]/80 to-[#0B272C]/95"></div>
+  <!-- CTA -->
+  <section class="page-cta">
+    <div class="page-cta__bg">
+      <img src="{{ site.baseurl }}/images/pools-1024.webp" alt="">
+      <div class="page-cta__overlay"></div>
     </div>
-
-    <div class="container mx-auto px-4 text-center relative z-10">
-      <h2 class="text-4xl md:text-5xl font-bold mb-8" data-aos="fade-up">
+    <div class="container relative z-10 text-center">
+      <span class="section-eyebrow" data-aos="fade-up">Get Started</span>
+      <h2 class="page-cta__title" data-aos="fade-up" data-aos-delay="100">
         Ready to Take the <span class="gradient-text">Pill</span>?
       </h2>
-      <p class="text-xl text-white/80 mb-10 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">
+      <p class="page-cta__lede" data-aos="fade-up" data-aos-delay="200">
         Start your journey with Salvium today and be part of the next generation of Private DeFi.
       </p>
-      <a href="{% link about.html %}"
-        class="btn-primary px-12 py-4 text-lg font-semibold hover:opacity-90 transition-opacity inline-block"
-        data-aos="fade-up" data-aos-delay="200">
+      <a href="{% link about.html %}" class="btn-primary page-cta__btn" data-aos="fade-up" data-aos-delay="300">
         Get Started Now
       </a>
     </div>

--- a/exchanges.html
+++ b/exchanges.html
@@ -6,28 +6,25 @@ redirect_from:
 ---
 
 <main class="relative z-10">
-    <!-- Hero Section -->
-    <section class="relative">
-        <!-- Hero Image -->
-        <div class="absolute inset-0">
+    <!-- Hero -->
+    <section class="page-hero">
+        <div class="page-hero__bg">
             <picture>
                 <source srcset="{{ site.baseurl }}/images/newimages/Page Headers/Exchange Header-1024.webp"
                     type="image/webp">
-                <img src="{{ site.baseurl }}/images/newimages/Page Headers/Exchange Header-1024.webp"
-                    alt="Exchanges Header" class="w-full h-full object-cover opacity-30">
+                <img src="{{ site.baseurl }}/images/newimages/Page Headers/Exchange Header-1024.webp" alt="">
             </picture>
-            <div class="absolute inset-0 bg-gradient-to-r from-black to-transparent opacity-75"></div>
+            <div class="page-hero__overlay"></div>
         </div>
-        <div class="relative z-10 py-24 lg:py-32">
-            <div class="container mx-auto px-4">
-                <div class="max-w-4xl mx-auto text-center">
-                    <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 text-center">
-                        Available <span class="gradient-text">Exchanges</span>
-                    </h1>
-                    <p class="text-xl text-gray-300 mb-8 text-center mx-auto max-w-2xl">
-                        Trade Salvium on these trusted platforms
-                    </p>
-                </div>
+        <div class="container relative z-10">
+            <div class="page-hero__inner" data-aos="fade-up" data-aos-duration="900">
+                <span class="section-eyebrow">Where to Buy</span>
+                <h1 class="page-hero__title">
+                    Available <span class="gradient-text">Exchanges</span>
+                </h1>
+                <p class="page-hero__lede">
+                    Trade Salvium on these trusted platforms.
+                </p>
             </div>
         </div>
     </section>
@@ -87,25 +84,21 @@ redirect_from:
     </div>
 </main>
 
-<!-- CTA Section -->
-<section class="py-16 relative overflow-hidden bg-[#0B272C] mt-8 mb-0">
-    <!-- Background Decoration -->
-    <div class="absolute inset-0">
-        <img src="{{ site.baseurl }}/images/pools-1024.webp" alt=""
-            class="absolute w-full h-full object-cover opacity-20">
-        <div class="absolute inset-0 bg-gradient-to-b from-[#0B272C]/95 via-[#0B272C]/80 to-[#0B272C]/95"></div>
+<!-- CTA -->
+<section class="page-cta">
+    <div class="page-cta__bg">
+        <img src="{{ site.baseurl }}/images/pools-1024.webp" alt="">
+        <div class="page-cta__overlay"></div>
     </div>
-
-    <div class="container mx-auto px-4 text-center relative z-10">
-        <h2 class="text-4xl md:text-5xl font-bold mb-8" data-aos="fade-up">
+    <div class="container relative z-10 text-center">
+        <span class="section-eyebrow" data-aos="fade-up">Get Started</span>
+        <h2 class="page-cta__title" data-aos="fade-up" data-aos-delay="100">
             Ready to Take the <span class="gradient-text">Pill</span>?
         </h2>
-        <p class="text-xl text-white/80 mb-10 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">
+        <p class="page-cta__lede" data-aos="fade-up" data-aos-delay="200">
             Start your journey with Salvium today and be part of the next generation of Private DeFi.
         </p>
-        <a href="{% link about.html %}"
-            class="btn-primary px-12 py-4 text-lg font-semibold hover:opacity-90 transition-opacity inline-block"
-            data-aos="fade-up" data-aos-delay="200">
+        <a href="{% link about.html %}" class="btn-primary page-cta__btn" data-aos="fade-up" data-aos-delay="300">
             Get Started Now
         </a>
     </div>

--- a/faq.html
+++ b/faq.html
@@ -7,24 +7,21 @@ redirect_from:
 ---
 
 <main class="relative z-10">
-    <!-- Hero Section -->
-    <section class="relative">
-        <!-- Hero Image -->
-        <div class="absolute inset-0">
-            <img src="{{ site.baseurl }}/images/newimages/Page Headers/FAQ Header-1024.webp" alt="FAQ Header"
-                class="w-full h-full object-cover opacity-30">
-            <div class="absolute inset-0 bg-gradient-to-r from-black to-transparent opacity-75"></div>
+    <!-- Hero -->
+    <section class="page-hero">
+        <div class="page-hero__bg">
+            <img src="{{ site.baseurl }}/images/newimages/Page Headers/FAQ Header-1024.webp" alt="">
+            <div class="page-hero__overlay"></div>
         </div>
-        <div class="relative z-10 py-24 lg:py-32">
-            <div class="container mx-auto px-4">
-                <div class="max-w-4xl mx-auto text-center">
-                    <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 text-center">
-                        Frequently Asked <span class="gradient-text">Questions</span>
-                    </h1>
-                    <p class="text-xl text-gray-300 mb-8 text-center mx-auto max-w-2xl">
-                        Find answers to common questions about Salvium's technology, features, and ecosystem
-                    </p>
-                </div>
+        <div class="container relative z-10">
+            <div class="page-hero__inner" data-aos="fade-up" data-aos-duration="900">
+                <span class="section-eyebrow">Help Center</span>
+                <h1 class="page-hero__title">
+                    Frequently Asked <span class="gradient-text">Questions</span>
+                </h1>
+                <p class="page-hero__lede">
+                    Find answers to common questions about Salvium's technology, features, and ecosystem.
+                </p>
             </div>
         </div>
     </section>
@@ -217,25 +214,21 @@ redirect_from:
         </div>
     </section>
 
-    <!-- CTA Section -->
-    <section class="py-24 relative overflow-hidden bg-[#0B272C] mt-4">
-        <!-- Background Decoration -->
-        <div class="absolute inset-0">
-            <img src="{{ site.baseurl }}/images/pools-1024.webp" alt=""
-                class="absolute w-full h-full object-cover opacity-20">
-            <div class="absolute inset-0 bg-gradient-to-b from-[#0B272C]/95 via-[#0B272C]/80 to-[#0B272C]/95"></div>
+    <!-- CTA -->
+    <section class="page-cta">
+        <div class="page-cta__bg">
+            <img src="{{ site.baseurl }}/images/pools-1024.webp" alt="">
+            <div class="page-cta__overlay"></div>
         </div>
-
-        <div class="container mx-auto px-4 text-center relative z-10">
-            <h2 class="text-4xl md:text-5xl font-bold mb-8" data-aos="fade-up">
+        <div class="container relative z-10 text-center">
+            <span class="section-eyebrow" data-aos="fade-up">Get Started</span>
+            <h2 class="page-cta__title" data-aos="fade-up" data-aos-delay="100">
                 Ready to Take the <span class="gradient-text">Pill</span>?
             </h2>
-            <p class="text-xl text-white/80 mb-10 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">
+            <p class="page-cta__lede" data-aos="fade-up" data-aos-delay="200">
                 Start your journey with Salvium today and be part of the next generation of Private DeFi.
             </p>
-            <a href="{% link about.html %}"
-                class="btn-primary px-12 py-4 text-lg font-semibold hover:opacity-90 transition-opacity inline-block"
-                data-aos="fade-up" data-aos-delay="200">
+            <a href="{% link about.html %}" class="btn-primary page-cta__btn" data-aos="fade-up" data-aos-delay="300">
                 Get Started Now
             </a>
         </div>

--- a/index.html
+++ b/index.html
@@ -3,166 +3,161 @@ layout: default
 title: Home
 ---
 
-<!-- Main Content -->
-<section class="relative pt-32 pb-20 lg:pt-48 lg:pb-32 overflow-hidden">
-    <div class="absolute inset-0 z-0">
-        <img src="{{ site.baseurl }}/images/wide-hero-1024.webp" alt="Hero Background"
-            class="w-full h-full object-cover opacity-40">
-        <div class="absolute inset-0 bg-gradient-to-b from-[#1e1e1e]/80 via-[#1e1e1e]/50 to-[#1e1e1e]"></div>
+<!-- Hero -->
+<section class="page-hero">
+    <div class="page-hero__bg">
+        <img src="{{ site.baseurl }}/images/wide-hero-1024.webp" alt="">
+        <div class="page-hero__overlay"></div>
     </div>
-    <div class="relative z-10">
-        <div class="container mx-auto px-4">
-            <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-                <div class="hero-content text-left mobile-center aos-init aos-animate" data-aos="fade-right">
-                    <h1
-                        class="text-4xl md:text-5xl lg:text-6xl font-bold mb-4 md:mb-6 mobile-smaller-text text-white !opacity-100 hero-text">
-                        The Future of <span class="gradient-text !opacity-100">Private DeFi</span>
-                    </h1>
-                    <p class="text-lg md:text-xl text-gray-100 mb-6 md:mb-8 !opacity-100 hero-text">
-                        Layer 1 blockchain that balances privacy and regulations.
-                    </p>
-                    <div class="hero-buttons mb-8 md:mb-12 flex flex-col md:flex-row gap-4">
-                        <a href="{% link about.html %}"
-                            class="btn-primary px-6 md:px-8 py-3 !text-white font-semibold inline-flex items-center justify-center mobile-full rounded-none">
-                            Get Started
-                        </a>
-                        <a href="https://salvium.github.io/salvium_docs/"
-                            class="px-6 md:px-8 py-3 border border-[#40E0D0] text-white hover:bg-[#40E0D0]/10 transition-colors font-semibold inline-flex items-center justify-center mobile-full rounded-none">
-                            Learn More
-                        </a>
-                    </div>
-                    <!-- Trust indicators -->
-                    <div class="trust-indicators flex flex-wrap items-center gap-4 xs:gap-6 sm:gap-8 mt-6 sm:mt-8">
-                        <div
-                            class="trust-indicator flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-[#40E0D0]/5 transition-colors">
-                            <img src="./images/lock-icon.svg" alt="Private" class="w-8 h-8 sm:w-9 sm:h-9">
-                            <span
-                                class="text-lg sm:text-xl font-medium whitespace-nowrap text-white opacity-100">Private</span>
-                        </div>
-                        <div
-                            class="trust-indicator flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-[#40E0D0]/5 transition-colors">
-                            <img src="./images/shield-icon.svg" alt="Compliant" class="w-8 h-8 sm:w-9 sm:h-9">
-                            <span
-                                class="text-lg sm:text-xl font-medium whitespace-nowrap text-white opacity-100">Compliant</span>
-                        </div>
-                        <div
-                            class="trust-indicator flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-[#40E0D0]/5 transition-colors">
-                            <div class="w-8 h-8 sm:w-9 sm:h-9 flex items-center justify-center" style="color: #40E0D0;">
-                                <i class="fa-solid fa-network-wired text-2xl"></i>
-                            </div>
-                            <span
-                                class="text-lg sm:text-xl font-medium whitespace-nowrap text-white opacity-100">Programmable</span>
-                        </div>
-                    </div>
+    <div class="container relative z-10">
+        <div class="page-hero__inner" data-aos="fade-up" data-aos-duration="900">
+            <span class="section-eyebrow">Private &middot; Compliant &middot; Programmable</span>
+            <h1 class="page-hero__title">
+                The Future of <span class="gradient-text">Private DeFi</span>
+            </h1>
+            <p class="page-hero__lede">
+                Layer 1 blockchain that balances privacy and regulations.
+            </p>
+            <div class="page-hero__cta">
+                <a href="{% link about.html %}" class="btn-primary page-hero__btn">
+                    Get Started
+                </a>
+                <a href="https://salvium.github.io/salvium_docs/" class="page-hero__btn page-hero__btn--ghost">
+                    Learn More <span aria-hidden="true">&rarr;</span>
+                </a>
+            </div>
+            <div class="trust-strip" aria-label="Salvium properties">
+                <div class="trust-strip__item">
+                    <img src="{{ site.baseurl }}/images/lock-icon.svg" alt="" class="trust-strip__icon">
+                    <span class="trust-strip__label">Private</span>
+                </div>
+                <span class="trust-strip__sep" aria-hidden="true"></span>
+                <div class="trust-strip__item">
+                    <img src="{{ site.baseurl }}/images/shield-icon.svg" alt="" class="trust-strip__icon">
+                    <span class="trust-strip__label">Compliant</span>
+                </div>
+                <span class="trust-strip__sep" aria-hidden="true"></span>
+                <div class="trust-strip__item">
+                    <i class="fa-solid fa-network-wired trust-strip__icon-fa" aria-hidden="true"></i>
+                    <span class="trust-strip__label">Programmable</span>
                 </div>
             </div>
         </div>
     </div>
 </section>
 
-<!-- Features Section -->
-<section class="py-20 relative">
-    <div class="container mx-auto px-4">
-        <div class="text-center mb-16">
-            <h2 class="text-4xl font-bold mb-6 aos-init aos-animate" data-aos="fade-up">
-                Why Choose <span class="gradient-text">Salvium</span>
-            </h2>
-            <p class="text-lg text-gray-300 mb-6 md:mb-8 max-w-3xl mx-auto aos-init aos-animate" data-aos="fade-up"
-                data-aos-delay="100">
+<!-- MiCAR milestone banner -->
+<aside class="milestone-banner" data-aos="fade-up" data-aos-delay="100">
+    <div class="container milestone-banner__inner">
+        <div class="milestone-banner__icon" aria-hidden="true">
+            <i class="fa-solid fa-shield-halved"></i>
+        </div>
+        <div class="milestone-banner__copy">
+            <span class="section-eyebrow milestone-banner__eyebrow">February 2026 &middot; Legal Opinion</span>
+            <p class="milestone-banner__headline">
+                Independent legal analysis confirms <strong>SAL is eligible for listing on MiCAR-authorised exchanges</strong>.
+            </p>
+        </div>
+        <a href="{% post_url 2026-02-23-micar-legal-opinion %}" class="milestone-banner__link">
+            Read the analysis <span aria-hidden="true">&rarr;</span>
+        </a>
+    </div>
+</aside>
+
+<!-- Why Choose Salvium -->
+<section class="page-section home-why">
+    <div class="container">
+        <div class="page-section__head" data-aos="fade-up">
+            <span class="section-eyebrow">Why Salvium</span>
+            <h2 class="page-section__title">Why Choose <span class="gradient-text">Salvium</span></h2>
+            <p class="page-section__lede">
                 Privacy, compliance, and smart contracts form the foundation of a truly sovereign financial future.
             </p>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            <!-- Privacy Feature -->
-            <div class="ecosystem-card aos-init aos-animate" data-aos="fade-up" data-aos-delay="100">
-                <img src="./images/newimages/Page%20Headers/Litepaper%20Header.webp" alt="Privacy Feature"
-                    class="card-image opacity-100">
+            <article class="ecosystem-card page-card" data-aos="fade-up" data-aos-delay="100">
+                <div class="page-card__media">
+                    <img src="{{ site.baseurl }}/images/newimages/Page%20Headers/Litepaper%20Header.webp" alt="">
+                </div>
                 <div class="card-content">
                     <span class="card-tag">Privacy</span>
                     <h3 class="card-title">Privacy by Design</h3>
                     <p class="card-description">Built on robust cryptographic foundations with zero-knowledge proofs
                         for uncompromising security and confidentiality.</p>
                 </div>
-            </div>
-
-            <!-- Compliance Feature -->
-            <div class="ecosystem-card aos-init aos-animate" data-aos="fade-up" data-aos-delay="200">
-                <img src="./images/newimages/Page%20Headers/Exchange%20Header.webp" alt="Compliance Feature"
-                    class="card-image opacity-100">
+            </article>
+            <article class="ecosystem-card page-card" data-aos="fade-up" data-aos-delay="200">
+                <div class="page-card__media">
+                    <img src="{{ site.baseurl }}/images/newimages/Page%20Headers/Exchange%20Header.webp" alt="">
+                </div>
                 <div class="card-content">
                     <span class="card-tag">Compliance</span>
                     <h3 class="card-title">Regulatory Resilience</h3>
                     <p class="card-description">One of the few privacy-focused chains striving for MiCA
-                        compliance—designed to thrive where others cannot operate.</p>
+                        compliance&mdash;designed to thrive where others cannot operate.</p>
                 </div>
-            </div>
-
-            <!-- Programmable Feature -->
-            <div class="ecosystem-card aos-init aos-animate" data-aos="fade-up" data-aos-delay="300">
-                <img src="./images/newimages/Page%20Headers/Pools%20Header.webp" alt="Programmable Feature"
-                    class="card-image opacity-100">
+            </article>
+            <article class="ecosystem-card page-card" data-aos="fade-up" data-aos-delay="300">
+                <div class="page-card__media">
+                    <img src="{{ site.baseurl }}/images/newimages/Page%20Headers/Pools%20Header.webp" alt="">
+                </div>
                 <div class="card-content">
                     <span class="card-tag">Programmable</span>
                     <h3 class="card-title">Privacy Meets Possibility</h3>
                     <p class="card-description">Developing private smart contract capabilities for DeFi,
-                        stablecoins, and more—all while preserving transaction confidentiality.</p>
+                        stablecoins, and more&mdash;all while preserving transaction confidentiality.</p>
                 </div>
-            </div>
+            </article>
         </div>
     </div>
 </section>
 
-<!-- Ecosystem Section -->
-<div class="mb-8">
-    <div class="container mx-auto px-4 relative">
-        <div class="text-center mb-8">
-            <h2 class="text-4xl font-bold mb-4 aos-init" data-aos="fade-up">
-                Salvium <span class="gradient-text">Ecosystem</span>
-            </h2>
-            <p class="text-lg text-gray-300 max-w-2xl mx-auto aos-init" data-aos="fade-up" data-aos-delay="100">
-                Discover the key components powering our privacy-preserving network
+<div class="page-divider" aria-hidden="true"></div>
+
+<!-- Salvium Ecosystem -->
+<section class="page-section home-ecosystem">
+    <div class="container">
+        <div class="page-section__head" data-aos="fade-up">
+            <span class="section-eyebrow">Ecosystem</span>
+            <h2 class="page-section__title">Salvium <span class="gradient-text">Ecosystem</span></h2>
+            <p class="page-section__lede">
+                Discover the key components powering our privacy-preserving network.
             </p>
         </div>
 
-        <div class="cards-grid mt-6 aos-init" data-aos="fade-up" data-aos-delay="100">
-            <!-- Governance Card -->
-            <div class="ecosystem-card">
-                <div class="relative w-full h-48 md:h-64 overflow-hidden">
-                    <img src="./images/newimages/ecosystem/governance.webp" alt="Governance"
-                        class="w-full h-full object-cover opacity-100">
+        <div class="cards-grid">
+            <article class="ecosystem-card page-card" data-aos="fade-up" data-aos-delay="100">
+                <div class="page-card__media">
+                    <img src="{{ site.baseurl }}/images/newimages/ecosystem/governance.webp" alt="">
                 </div>
                 <div class="card-content">
                     <span class="card-tag">Governance</span>
-                    <h3 class="card-title">Decentralized & Community-Driven</h3>
+                    <h3 class="card-title">Decentralized &amp; Community-Driven</h3>
                     <p class="card-description">A fair and open ecosystem where miners, stakers, and developers
                         collectively shape the future of privacy-focused finance.</p>
                     <a href="{% link about.html %}" class="card-link">Learn More <i
                             class="fa-solid fa-chevron-down"></i></a>
                 </div>
-            </div>
+            </article>
 
-            <!-- Staking Card -->
-            <div class="ecosystem-card">
-                <div class="relative w-full h-48 md:h-64 overflow-hidden">
-                    <img src="./images/newimages/ecosystem/yield.webp" alt="Staking & Yield"
-                        class="w-full h-full object-cover opacity-100">
+            <article class="ecosystem-card page-card" data-aos="fade-up" data-aos-delay="200">
+                <div class="page-card__media">
+                    <img src="{{ site.baseurl }}/images/newimages/ecosystem/yield.webp" alt="">
                 </div>
                 <div class="card-content">
-                    <span class="card-tag">Staking & Yield</span>
+                    <span class="card-tag">Staking &amp; Yield</span>
                     <h3 class="card-title">Earn While Securing the Network</h3>
                     <p class="card-description">Stake SAL tokens to strengthen the ecosystem and receive 20% of
                         block rewards as incentive.</p>
                     <a href="{% link about.html %}" class="card-link">Learn More <i
                             class="fa-solid fa-chevron-down"></i></a>
                 </div>
-            </div>
+            </article>
 
-            <!-- Future Card -->
-            <div class="ecosystem-card">
-                <div class="relative w-full h-48 md:h-64 overflow-hidden">
-                    <img src="./images/newimages/ecosystem/defi-future.webp" alt="Future"
-                        class="w-full h-full object-cover opacity-100">
+            <article class="ecosystem-card page-card" data-aos="fade-up" data-aos-delay="300">
+                <div class="page-card__media">
+                    <img src="{{ site.baseurl }}/images/newimages/ecosystem/defi-future.webp" alt="">
                 </div>
                 <div class="card-content">
                     <span class="card-tag">Future</span>
@@ -172,13 +167,11 @@ title: Home
                     <a href="{% link about.html %}" class="card-link">Learn More <i
                             class="fa-solid fa-chevron-down"></i></a>
                 </div>
-            </div>
+            </article>
 
-            <!-- Additional Card -->
-            <div class="ecosystem-card">
-                <div class="relative w-full h-48 md:h-64 overflow-hidden">
-                    <img src="./images/newimages/ecosystem/compliance.webp" alt="Compliance"
-                        class="w-full h-full object-cover opacity-100">
+            <article class="ecosystem-card page-card" data-aos="fade-up" data-aos-delay="400">
+                <div class="page-card__media">
+                    <img src="{{ site.baseurl }}/images/newimages/ecosystem/compliance.webp" alt="">
                 </div>
                 <div class="card-content">
                     <span class="card-tag">Compliance</span>
@@ -188,29 +181,75 @@ title: Home
                     <a href="{% link about.html %}" class="card-link">Learn More <i
                             class="fa-solid fa-chevron-down"></i></a>
                 </div>
-            </div>
+            </article>
         </div>
     </div>
-</div>
+</section>
 
-<!-- CTA Section -->
-<section class="py-16 relative overflow-hidden bg-[#0B272C] mt-8">
-    <!-- Background Decoration -->
-    <div class="absolute inset-0">
-        <img src="./images/pools-1024.webp" alt="" class="absolute w-full h-full object-cover opacity-20">
-        <div class="absolute inset-0 bg-gradient-to-b from-[#0B272C]/95 via-[#0B272C]/80 to-[#0B272C]/95"></div>
+<div class="page-divider" aria-hidden="true"></div>
+
+<!-- Latest from the Blog -->
+<section class="page-section home-latest">
+    <div class="container">
+        <div class="page-section__head page-section__head--row" data-aos="fade-up">
+            <div>
+                <span class="section-eyebrow">Latest</span>
+                <h2 class="page-section__title">From the <span class="gradient-text">Blog</span></h2>
+                <p class="page-section__lede">Updates, deep-dives, and milestones from the Salvium team.</p>
+            </div>
+            <a href="{% link blog/index.html %}" class="home-latest__viewall">
+                All posts <span aria-hidden="true">&rarr;</span>
+            </a>
+        </div>
+
+        <div class="cards-grid">
+            {% for post in site.posts limit: 3 %}
+            <article class="ecosystem-card page-card home-post-card"
+                     data-aos="fade-up"
+                     data-aos-delay="{{ forloop.index | times: 100 }}">
+                <a href="{{ post.url | relative_url }}" class="home-post-card__media-link" aria-hidden="true" tabindex="-1">
+                    <div class="page-card__media">
+                        {% if post.image %}
+                        <img src="{{ post.image | relative_url }}" alt="">
+                        {% else %}
+                        <img src="{{ '/images/newimages/Page Headers/Blog Header.jpg' | relative_url }}" alt="">
+                        {% endif %}
+                    </div>
+                </a>
+                <div class="card-content">
+                    <div class="home-post-card__meta">
+                        {% if post.categories.size > 0 %}
+                        <span class="card-tag">{{ post.categories | first }}</span>
+                        {% endif %}
+                        <time datetime="{{ post.date | date_to_xmlschema }}" class="home-post-card__date">{{ post.date | date: "%b %d, %Y" }}</time>
+                    </div>
+                    <h3 class="card-title">
+                        <a href="{{ post.url | relative_url }}" class="home-post-card__title-link">{{ post.title }}</a>
+                    </h3>
+                    <p class="card-description">{{ post.excerpt | strip_html | truncatewords: 25 }}</p>
+                    <a href="{{ post.url | relative_url }}" class="card-link">Read post <i class="fa-solid fa-arrow-right"></i></a>
+                </div>
+            </article>
+            {% endfor %}
+        </div>
     </div>
+</section>
 
-    <div class="container mx-auto px-4 text-center relative z-10">
-        <h2 class="text-4xl md:text-5xl font-bold mb-8 aos-init" data-aos="fade-up">
+<!-- CTA -->
+<section class="page-cta">
+    <div class="page-cta__bg">
+        <img src="{{ site.baseurl }}/images/pools-1024.webp" alt="">
+        <div class="page-cta__overlay"></div>
+    </div>
+    <div class="container relative z-10 text-center">
+        <span class="section-eyebrow" data-aos="fade-up">Get Started</span>
+        <h2 class="page-cta__title" data-aos="fade-up" data-aos-delay="100">
             Join the <span class="gradient-text">Private DeFi</span> Revolution
         </h2>
-        <p class="text-xl text-white/80 mb-10 max-w-2xl mx-auto aos-init" data-aos="fade-up" data-aos-delay="100">
+        <p class="page-cta__lede" data-aos="fade-up" data-aos-delay="200">
             Experience the future of private finance with Salvium's innovative blockchain technology.
         </p>
-        <a href="{% link download.html %}"
-            class="btn-primary px-12 py-4 text-lg font-semibold hover:opacity-90 transition-opacity inline-block aos-init"
-            data-aos="fade-up" data-aos-delay="200">
+        <a href="{% link download.html %}" class="btn-primary page-cta__btn" data-aos="fade-up" data-aos-delay="300">
             Get Started Now
         </a>
     </div>

--- a/js/particles-config.js
+++ b/js/particles-config.js
@@ -1,90 +1,96 @@
-particlesJS('particles-js', {
-  particles: {
-    number: {
-      value: 80,
-      density: {
-        enable: true,
-        value_area: 800
-      }
-    },
-    color: {
-      value: '#ffffff'
-    },
-    shape: {
-      type: 'circle'
-    },
-    opacity: {
-      value: 0.5,
-      random: false,
-      anim: {
-        enable: false
-      }
-    },
-    size: {
-      value: 3,
-      random: true,
-      anim: {
-        enable: false
-      }
-    },
-    line_linked: {
-      enable: true,
-      distance: 150,
-      color: '#ffffff',
-      opacity: 0.4,
-      width: 1
-    },
-    move: {
-      enable: true,
-      speed: 6,
-      direction: 'none',
-      random: false,
-      straight: false,
-      out_mode: 'out',
-      bounce: false,
-      attract: {
-        enable: false
-      }
-    }
-  },
-  interactivity: {
-    detect_on: 'canvas',
-    events: {
-      onhover: {
-        enable: true,
-        mode: 'repulse'
-      },
-      onclick: {
-        enable: true,
-        mode: 'push'
-      },
-      resize: true
-    },
-    modes: {
-      grab: {
-        distance: 400,
-        line_linked: {
-          opacity: 1
+(function () {
+  var isSmall = window.matchMedia('(max-width: 768px)').matches;
+  var reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  var lowPower = isSmall || reducedMotion;
+
+  particlesJS('particles-js', {
+    particles: {
+      number: {
+        value: lowPower ? 28 : 80,
+        density: {
+          enable: true,
+          value_area: 800
         }
       },
-      bubble: {
-        distance: 400,
-        size: 40,
-        duration: 2,
-        opacity: 8,
-        speed: 3
+      color: {
+        value: '#ffffff'
       },
-      repulse: {
-        distance: 200,
-        duration: 0.4
+      shape: {
+        type: 'circle'
       },
-      push: {
-        particles_nb: 4
+      opacity: {
+        value: 0.5,
+        random: false,
+        anim: {
+          enable: false
+        }
       },
-      remove: {
-        particles_nb: 2
+      size: {
+        value: 3,
+        random: true,
+        anim: {
+          enable: false
+        }
+      },
+      line_linked: {
+        enable: true,
+        distance: lowPower ? 110 : 150,
+        color: '#ffffff',
+        opacity: 0.4,
+        width: 1
+      },
+      move: {
+        enable: true,
+        speed: reducedMotion ? 1.5 : 6,
+        direction: 'none',
+        random: false,
+        straight: false,
+        out_mode: 'out',
+        bounce: false,
+        attract: {
+          enable: false
+        }
       }
-    }
-  },
-  retina_detect: true
-});
+    },
+    interactivity: {
+      detect_on: 'canvas',
+      events: {
+        onhover: {
+          enable: !lowPower,
+          mode: 'repulse'
+        },
+        onclick: {
+          enable: !lowPower,
+          mode: 'push'
+        },
+        resize: true
+      },
+      modes: {
+        grab: {
+          distance: 400,
+          line_linked: {
+            opacity: 1
+          }
+        },
+        bubble: {
+          distance: 400,
+          size: 40,
+          duration: 2,
+          opacity: 8,
+          speed: 3
+        },
+        repulse: {
+          distance: 200,
+          duration: 0.4
+        },
+        push: {
+          particles_nb: 4
+        },
+        remove: {
+          particles_nb: 2
+        }
+      }
+    },
+    retina_detect: true
+  });
+})();

--- a/papers.html
+++ b/papers.html
@@ -7,23 +7,21 @@ redirect_from:
 
 <!-- Main Content -->
 <main class="relative z-10">
-    <!-- Hero Section -->
-    <section class="relative">
-        <div class="absolute inset-0">
-            <img src="{{ site.baseurl }}/images/newimages/Page Headers/Litepaper Header-1024.webp" alt="Papers Header"
-                class="w-full h-full object-cover opacity-30">
-            <div class="absolute inset-0 bg-gradient-to-r from-black to-transparent opacity-75"></div>
+    <!-- Hero -->
+    <section class="page-hero">
+        <div class="page-hero__bg">
+            <img src="{{ site.baseurl }}/images/newimages/Page Headers/Litepaper Header-1024.webp" alt="">
+            <div class="page-hero__overlay"></div>
         </div>
-        <div class="relative z-10 py-24 lg:py-32">
-            <div class="container mx-auto px-4">
-                <div class="max-w-4xl mx-auto text-center">
-                    <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
-                        Salvium <span class="gradient-text">Papers</span>
-                    </h1>
-                    <p class="text-xl text-gray-300">
-                        Explore our technical documentation and research
-                    </p>
-                </div>
+        <div class="container relative z-10">
+            <div class="page-hero__inner" data-aos="fade-up" data-aos-duration="900">
+                <span class="section-eyebrow">Documentation</span>
+                <h1 class="page-hero__title">
+                    Salvium <span class="gradient-text">Papers</span>
+                </h1>
+                <p class="page-hero__lede">
+                    Explore our technical documentation and research.
+                </p>
             </div>
         </div>
     </section>
@@ -225,25 +223,21 @@ redirect_from:
         </div>
     </div>
 
-    <!-- CTA Section -->
-    <section class="py-16 relative overflow-hidden bg-[#0B272C] mt-8">
-        <!-- Background Decoration -->
-        <div class="absolute inset-0">
-            <img src="{{ site.baseurl }}/images/pools-1024.webp" alt=""
-                class="absolute w-full h-full object-cover opacity-20">
-            <div class="absolute inset-0 bg-gradient-to-b from-[#0B272C]/95 via-[#0B272C]/80 to-[#0B272C]/95"></div>
+    <!-- CTA -->
+    <section class="page-cta">
+        <div class="page-cta__bg">
+            <img src="{{ site.baseurl }}/images/pools-1024.webp" alt="">
+            <div class="page-cta__overlay"></div>
         </div>
-
-        <div class="container mx-auto px-4 text-center relative z-10">
-            <h2 class="text-4xl md:text-5xl font-bold mb-8" data-aos="fade-up">
+        <div class="container relative z-10 text-center">
+            <span class="section-eyebrow" data-aos="fade-up">Get Started</span>
+            <h2 class="page-cta__title" data-aos="fade-up" data-aos-delay="100">
                 Ready to Take the <span class="gradient-text">Pill</span>?
             </h2>
-            <p class="text-xl text-white/80 mb-10 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">
+            <p class="page-cta__lede" data-aos="fade-up" data-aos-delay="200">
                 Start your journey with Salvium today and be part of the next generation of Private DeFi.
             </p>
-            <a href="{% link download.html %}"
-                class="btn-primary px-12 py-4 text-lg font-semibold hover:opacity-90 transition-opacity inline-block"
-                data-aos="fade-up" data-aos-delay="200">
+            <a href="{% link download.html %}" class="btn-primary page-cta__btn" data-aos="fade-up" data-aos-delay="300">
                 Get Started Now
             </a>
         </div>

--- a/pools.html
+++ b/pools.html
@@ -5,23 +5,21 @@ redirect_from:
   - /pools.html
 ---
 <main class="relative z-10">
-    <!-- Hero Section -->
-    <section class="relative bg-[#1e1e1e] overflow-hidden">
-        <div class="absolute inset-0">
-            <img src="{{ site.baseurl }}/images/newimages/Page Headers/Pools Header-1024.webp" alt="Pools Header"
-                class="w-full h-full object-cover opacity-30">
-            <div class="absolute inset-0 bg-gradient-to-b from-[#1e1e1e]/80 to-[#1e1e1e]"></div>
+    <!-- Hero -->
+    <section class="page-hero">
+        <div class="page-hero__bg">
+            <img src="{{ site.baseurl }}/images/newimages/Page Headers/Pools Header-1024.webp" alt="">
+            <div class="page-hero__overlay"></div>
         </div>
-        <div class="relative z-10 py-24 lg:py-32">
-            <div class="container mx-auto px-4">
-                <div class="max-w-4xl mx-auto text-center">
-                    <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
-                        Mining <span class="gradient-text">Pools</span>
-                    </h1>
-                    <p class="text-xl text-gray-300 mb-8">
-                        Join our trusted mining pools and start earning Salvium rewards
-                    </p>
-                </div>
+        <div class="container relative z-10">
+            <div class="page-hero__inner" data-aos="fade-up" data-aos-duration="900">
+                <span class="section-eyebrow">Mining</span>
+                <h1 class="page-hero__title">
+                    Mining <span class="gradient-text">Pools</span>
+                </h1>
+                <p class="page-hero__lede">
+                    Join our trusted mining pools and start earning Salvium rewards.
+                </p>
             </div>
         </div>
     </section>
@@ -127,23 +125,21 @@ redirect_from:
     </section>
 </main>
 
-<!-- CTA Section -->
-<section class="py-16 relative overflow-hidden bg-[#0B272C] mt-8">
-    <div class="absolute inset-0">
-        <img src="{{ site.baseurl }}/images/pools-1024.webp" alt=""
-            class="absolute w-full h-full object-cover opacity-20">
-        <div class="absolute inset-0 bg-gradient-to-b from-[#0B272C]/95 via-[#0B272C]/80 to-[#0B272C]/95"></div>
+<!-- CTA -->
+<section class="page-cta">
+    <div class="page-cta__bg">
+        <img src="{{ site.baseurl }}/images/pools-1024.webp" alt="">
+        <div class="page-cta__overlay"></div>
     </div>
-    <div class="container mx-auto px-4 text-center relative z-10">
-        <h2 class="text-4xl md:text-5xl font-bold mb-8" data-aos="fade-up">
+    <div class="container relative z-10 text-center">
+        <span class="section-eyebrow" data-aos="fade-up">Get Started</span>
+        <h2 class="page-cta__title" data-aos="fade-up" data-aos-delay="100">
             Ready to Take the <span class="gradient-text">Pill</span>?
         </h2>
-        <p class="text-xl text-white/80 mb-10 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">
+        <p class="page-cta__lede" data-aos="fade-up" data-aos-delay="200">
             Start your journey with Salvium today and be part of the next generation of Private DeFi.
         </p>
-        <a href="{% link about.html %}"
-            class="btn-primary px-12 py-4 text-lg font-semibold hover:opacity-90 transition-opacity inline-block"
-            data-aos="fade-up" data-aos-delay="200">
+        <a href="{% link about.html %}" class="btn-primary page-cta__btn" data-aos="fade-up" data-aos-delay="300">
             Get Started Now
         </a>
     </div>

--- a/roadmap.html
+++ b/roadmap.html
@@ -7,26 +7,24 @@ redirect_from:
 ---
 
 <main class="relative z-10">
-    <!-- Hero Section -->
-    <section class="relative bg-[#1e1e1e] overflow-hidden">
-        <div class="absolute inset-0">
+    <!-- Hero -->
+    <section class="page-hero">
+        <div class="page-hero__bg">
             <picture>
                 <source srcset="{{ site.baseurl }}/images/newimages/Roadmap.webp" type="image/webp">
-                <img src="{{ site.baseurl }}/images/newimages/Roadmap.png" alt="Roadmap Header"
-                    class="w-full h-full object-cover opacity-30">
+                <img src="{{ site.baseurl }}/images/newimages/Roadmap.png" alt="">
             </picture>
-            <div class="absolute inset-0 bg-gradient-to-b from-[#1e1e1e]/80 to-[#1e1e1e]"></div>
+            <div class="page-hero__overlay"></div>
         </div>
-        <div class="relative z-10 py-24 lg:py-32">
-            <div class="container mx-auto px-4">
-                <div class="max-w-4xl mx-auto text-center">
-                    <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
-                        Salvium <span class="gradient-text">Roadmap</span>
-                    </h1>
-                    <p class="text-xl text-gray-300 mb-8">
-                        Our journey to revolutionize decentralized finance
-                    </p>
-                </div>
+        <div class="container relative z-10">
+            <div class="page-hero__inner" data-aos="fade-up" data-aos-duration="900">
+                <span class="section-eyebrow">Roadmap</span>
+                <h1 class="page-hero__title">
+                    Salvium <span class="gradient-text">Roadmap</span>
+                </h1>
+                <p class="page-hero__lede">
+                    Our journey to revolutionize decentralized finance.
+                </p>
             </div>
         </div>
     </section>
@@ -81,25 +79,21 @@ redirect_from:
         </div>
     </div>
 </main>
-<!-- CTA Section -->
-<section class="py-16 relative overflow-hidden bg-[#0B272C] mt-4">
-    <!-- Background Decoration -->
-    <div class="absolute inset-0">
-        <img src="{{ site.baseurl }}/images/pools-1024.webp" alt=""
-            class="absolute w-full h-full object-cover opacity-20">
-        <div class="absolute inset-0 bg-gradient-to-b from-[#0B272C]/95 via-[#0B272C]/80 to-[#0B272C]/95"></div>
+<!-- CTA -->
+<section class="page-cta">
+    <div class="page-cta__bg">
+        <img src="{{ site.baseurl }}/images/pools-1024.webp" alt="">
+        <div class="page-cta__overlay"></div>
     </div>
-
-    <div class="container mx-auto px-4 text-center relative z-10">
-        <h2 class="text-4xl md:text-5xl font-bold mb-8" data-aos="fade-up">
+    <div class="container relative z-10 text-center">
+        <span class="section-eyebrow" data-aos="fade-up">Get Started</span>
+        <h2 class="page-cta__title" data-aos="fade-up" data-aos-delay="100">
             Ready to Take the <span class="gradient-text">Pill</span>?
         </h2>
-        <p class="text-xl text-white/80 mb-10 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">
+        <p class="page-cta__lede" data-aos="fade-up" data-aos-delay="200">
             Start your journey with Salvium today and be part of the next generation of Private DeFi.
         </p>
-        <a href="{% link about.html %}"
-            class="btn-primary px-12 py-4 text-lg font-semibold hover:opacity-90 transition-opacity inline-block"
-            data-aos="fade-up" data-aos-delay="200">
+        <a href="{% link about.html %}" class="btn-primary page-cta__btn" data-aos="fade-up" data-aos-delay="300">
             Get Started Now
         </a>
     </div>

--- a/stats.html
+++ b/stats.html
@@ -6,27 +6,24 @@ redirect_from:
 ---
 
 <main>
-    <!-- Hero Section -->
-    <section class="relative">
-        <!-- Hero Image -->
-        <div class="absolute inset-0">
+    <!-- Hero -->
+    <section class="page-hero">
+        <div class="page-hero__bg">
             <picture>
-                <source srcset="./images/newimages/Stats.webp" type="image/webp">
-                <img src="{{ site.baseurl }}/images/newimages/Stats.png" alt="Statistics Header"
-                    class="w-full h-full object-cover opacity-30">
+                <source srcset="{{ site.baseurl }}/images/newimages/Stats.webp" type="image/webp">
+                <img src="{{ site.baseurl }}/images/newimages/Stats.png" alt="">
             </picture>
-            <div class="absolute inset-0 bg-gradient-to-r from-black to-transparent opacity-75"></div>
+            <div class="page-hero__overlay"></div>
         </div>
-        <div class="relative z-10 py-24 lg:py-32">
-            <div class="container mx-auto px-4 text-center">
-                <div class="max-w-4xl mx-auto">
-                    <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6 text-center">
-                        Network <span class="gradient-text">Statistics</span>
-                    </h1>
-                    <p class="text-xl text-gray-300 mb-8 text-center">
-                        Track Salvium's network performance, supply metrics, and market activity in real-time.
-                    </p>
-                </div>
+        <div class="container relative z-10">
+            <div class="page-hero__inner" data-aos="fade-up" data-aos-duration="900">
+                <span class="section-eyebrow">Live Data</span>
+                <h1 class="page-hero__title">
+                    Network <span class="gradient-text">Statistics</span>
+                </h1>
+                <p class="page-hero__lede">
+                    Track Salvium's network performance, supply metrics, and market activity in real-time.
+                </p>
             </div>
         </div>
     </section>
@@ -48,25 +45,21 @@ redirect_from:
     </section>
 </main>
 
-<!-- CTA Section -->
-<section class="py-16 relative overflow-hidden bg-[#0B272C] mt-8">
-    <!-- Background Decoration -->
-    <div class="absolute inset-0">
-        <img src="{{ site.baseurl }}/images/pools-1024.webp" alt=""
-            class="absolute w-full h-full object-cover opacity-20">
-        <div class="absolute inset-0 bg-gradient-to-b from-[#0B272C]/95 via-[#0B272C]/80 to-[#0B272C]/95"></div>
+<!-- CTA -->
+<section class="page-cta">
+    <div class="page-cta__bg">
+        <img src="{{ site.baseurl }}/images/pools-1024.webp" alt="">
+        <div class="page-cta__overlay"></div>
     </div>
-
-    <div class="container mx-auto px-4 text-center relative z-10">
-        <h2 class="text-4xl md:text-5xl font-bold mb-8" data-aos="fade-up">
+    <div class="container relative z-10 text-center">
+        <span class="section-eyebrow" data-aos="fade-up">Get Started</span>
+        <h2 class="page-cta__title" data-aos="fade-up" data-aos-delay="100">
             Ready to Take the <span class="gradient-text">Pill</span>?
         </h2>
-        <p class="text-xl text-white/80 mb-10 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">
+        <p class="page-cta__lede" data-aos="fade-up" data-aos-delay="200">
             Start your journey with Salvium today and be part of the next generation of Private DeFi.
         </p>
-        <a href="{% link download.html %}"
-            class="btn-primary px-12 py-4 text-lg font-semibold hover:opacity-90 transition-opacity inline-block"
-            data-aos="fade-up" data-aos-delay="200">
+        <a href="{% link download.html %}" class="btn-primary page-cta__btn" data-aos="fade-up" data-aos-delay="300">
             Get Started Now
         </a>
     </div>

--- a/tools.html
+++ b/tools.html
@@ -6,23 +6,21 @@ redirect_from:
 ---
 
 <main class="relative z-10">
-    <!-- Hero Section -->
-    <section class="relative bg-[#1e1e1e] overflow-hidden">
-        <div class="absolute inset-0">
-            <img src="{{ site.baseurl }}/images/newimages/Page Headers/Exchange Header-1024.webp" alt="Tools Header"
-                class="w-full h-full object-cover opacity-30">
-            <div class="absolute inset-0 bg-gradient-to-b from-[#1e1e1e]/80 to-[#1e1e1e]"></div>
+    <!-- Hero -->
+    <section class="page-hero">
+        <div class="page-hero__bg">
+            <img src="{{ site.baseurl }}/images/newimages/Page Headers/Exchange Header-1024.webp" alt="">
+            <div class="page-hero__overlay"></div>
         </div>
-        <div class="relative z-10 py-24 lg:py-32">
-            <div class="container mx-auto px-4">
-                <div class="max-w-4xl mx-auto text-center">
-                    <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
-                        Third Party <span class="gradient-text">Tools</span>
-                    </h1>
-                    <p class="text-xl text-gray-300 mb-8">
-                        Explore community-built tools and resources for Salvium
-                    </p>
-                </div>
+        <div class="container relative z-10">
+            <div class="page-hero__inner" data-aos="fade-up" data-aos-duration="900">
+                <span class="section-eyebrow">Ecosystem</span>
+                <h1 class="page-hero__title">
+                    Third Party <span class="gradient-text">Tools</span>
+                </h1>
+                <p class="page-hero__lede">
+                    Explore community-built tools and resources for Salvium.
+                </p>
             </div>
         </div>
     </section>
@@ -149,25 +147,21 @@ redirect_from:
     </section>
 
 </main>
-<!-- CTA Section -->
-<section class="py-16 relative overflow-hidden bg-[#0B272C] mt-8">
-    <!-- Background Decoration -->
-    <div class="absolute inset-0">
-        <img src="{{ site.baseurl }}/images/pools-1024.webp" alt=""
-            class="absolute w-full h-full object-cover opacity-20">
-        <div class="absolute inset-0 bg-gradient-to-b from-[#0B272C]/95 via-[#0B272C]/80 to-[#0B272C]/95"></div>
+<!-- CTA -->
+<section class="page-cta">
+    <div class="page-cta__bg">
+        <img src="{{ site.baseurl }}/images/pools-1024.webp" alt="">
+        <div class="page-cta__overlay"></div>
     </div>
-
-    <div class="container mx-auto px-4 text-center relative z-10">
-        <h2 class="text-4xl md:text-5xl font-bold mb-8" data-aos="fade-up">
+    <div class="container relative z-10 text-center">
+        <span class="section-eyebrow" data-aos="fade-up">Get Started</span>
+        <h2 class="page-cta__title" data-aos="fade-up" data-aos-delay="100">
             Ready to Take the <span class="gradient-text">Pill</span>?
         </h2>
-        <p class="text-xl text-white/80 mb-10 max-w-2xl mx-auto" data-aos="fade-up" data-aos-delay="100">
+        <p class="page-cta__lede" data-aos="fade-up" data-aos-delay="200">
             Start your journey with Salvium today and be part of the next generation of Private DeFi.
         </p>
-        <a href="{% link about.html %}"
-            class="btn-primary px-12 py-4 text-lg font-semibold hover:opacity-90 transition-opacity inline-block"
-            data-aos="fade-up" data-aos-delay="200">
+        <a href="{% link about.html %}" class="btn-primary page-cta__btn" data-aos="fade-up" data-aos-delay="300">
             Get Started Now
         </a>
     </div>


### PR DESCRIPTION
- Home page restructure: refined hero with credentials strip, MiCAR milestone banner, ecosystem grid, latest-from-the-blog section, CTA
- Site-wide page-hero / page-cta / page-section / page-card / page-divider / section-eyebrow tokens defined in css/pages.css
- Hero + CTA refresh on every top-level page (about, download, exchanges, papers, pools, roadmap, tools, community, donate, faq, stats) and the blog index, replacing inline Tailwind 2 arbitrary-value classes with explicit CSS that resolves consistently
- Blog post layout reworked with editorial header (eyebrow + tighter type + monospace meta) and a dedicated .post-page__* namespace
- _layouts/blog.html duplicate body removed; pages.css now linked from this layout so post pages get the new styles
- donate.html structural fixes (orphan closing tags + missing main tag)
- Mobile optimisations: ≤768px / ≤540px / (hover: none) breakpoints tighten hero+CTA padding, stack the trust strip and milestone banner, full-width hero CTA buttons, kill card hover-zoom on touch devices
- particles-config.js gated for ≤768px and prefers-reduced-motion: particles drop 80→28, line distance 150→110, hover/click off
- AOS data-aos-delay values realigned to 50ms increments (the library only ships pre-baked CSS for those, so 80/180/260/340 left elements stuck in their hidden initial state)
- html, body get overflow-x: hidden + max-width: 100% on the default layout to prevent any element from pushing the body past viewport